### PR TITLE
fix: Remove invalid Action processes.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,3 @@ jobs:
       run: dotnet test -c Release --no-build --no-restore --results-directory test-results --verbosity normal --collect:"XPlat Code Coverage" `
            -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=json,cobertura,lcov,teamcity,opencover
 
-    - name: Upload test results artefacts
-      if: github.repository_owner == 'casdoor' && github.event_name == 'push'
-      uses: actions/upload-artifact@v1.0.0
-      with:
-        name: "drop-ci-test-results"
-        path: './test-results'


### PR DESCRIPTION
Since dotnet test is not configured in casdoor-dotnet-sdk-example, the test-results folder is not created.